### PR TITLE
Expose the #compile method from pcap lib.

### DIFF
--- a/ext/pcaprub/pcaprub.c
+++ b/ext/pcaprub/pcaprub.c
@@ -419,6 +419,28 @@ rbpcap_setfilter(VALUE self, VALUE filter)
 }
 
 /*
+* call-seq:
+*   compile(filter)
+*
+* Raises an exception if "filter" has a syntax error
+*
+* Returns self if the filter is valid
+*/
+static VALUE
+rbpcap_compile(VALUE self, VALUE filter) {
+  struct bpf_program bpf;
+  u_int32_t mask = 0;
+  rbpcap_t *rbp;
+
+  Data_Get_Struct(self, rbpcap_t, rbp);
+  if(pcap_compile(rbp->pd, &bpf, RSTRING_PTR(filter), 0, mask) < 0) {
+    rb_raise(eBPFilterError, "invalid bpf filter");
+  } else {
+    return self;
+  }
+}
+
+/*
 * Activate the interface
 *
 * call-seq:
@@ -1309,6 +1331,7 @@ Init_pcaprub()
 
   rb_define_method(rb_cPcap, "next", rbpcap_next_data, 0);
   rb_define_method(rb_cPcap, "setfilter", rbpcap_setfilter, 1);
+  rb_define_method(rb_cPcap, "compile", rbpcap_compile, 1);
   rb_define_method(rb_cPcap, "setmonitor", rbpcap_setmonitor, 1);
   rb_define_method(rb_cPcap, "setsnaplen", rbpcap_setsnaplen, 1);
   rb_define_method(rb_cPcap, "settimeout", rbpcap_settimeout, 1);

--- a/lib/pcaprub/version.rb
+++ b/lib/pcaprub/version.rb
@@ -3,7 +3,7 @@ module PCAPRUB #:nodoc:
   module VERSION #:nodoc:
     
     MAJOR = 0
-    MINOR = 12
+    MINOR = 13
     TINY = 0
 
     STRING = [MAJOR, MINOR, TINY].join('.')


### PR DESCRIPTION
This will allow us to validate BPF strings in the UI without needing root permissions to open a live device.

Verification:
- [x] Ensure that `Pcap.create('lo').compile("port 112")` _does not_ raise an error
- [ ] Ensure that `Pcap.create('lo').compile("port 999999")` _does_ raise an error
